### PR TITLE
fix: sanitize-html missing types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 ### Bug Fixes
+- Fixed dependent projects failing to build without dependency `@types/sanitize-html`.
+
+## 3.1.1
+
+## 3.1.0
+### Bug Fixes
 - Added aria-label attributes to the social links.
 - Removed scaling limitation in viewport meta tag.
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
     "@types/react-router-dom": "^5.3.0",
+    "@types/sanitize-html": "^2.5.0",
     "@types/walk": "^2.3.1",
     "classnames": "^2.3.1",
     "front-matter": "^4.0.2",
@@ -53,7 +54,6 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
-    "@types/sanitize-html": "^2.5.0",
     "husky": "^7.0.2",
     "lint-staged": "^11.1.2",
     "prettier": "^2.4.1"


### PR DESCRIPTION
Fix error for dependent package builds missing `@types/sanitize-html` by moving from a dev depdendency to a regular dependency.

refs AOEpeople/aoe_technology_radar#106