### PR TITLE
fix: make build work with npm

### DIFF
--- a/dist_scripts/scripts/buildRadar.js
+++ b/dist_scripts/scripts/buildRadar.js
@@ -57,10 +57,10 @@ var runCommand = function (command) {
     });
 };
 var buildTemplate = function () {
-    var packageManager = fs.existsSync(paths.appYarnLock) ? "yarn" : "npx";
+    var packageManager = fs.existsSync(paths.appYarnLock) ? "yarn" : "npm";
     fs.emptyDirSync(paths.templateBuild);
     process.chdir(paths.template);
-    return runCommand(packageManager + " build");
+    return runCommand(packageManager + " run build");
 };
 buildTemplate().then(function () {
     fs.copySync(paths.templateBuild, paths.appBuild);

--- a/scripts/buildRadar.ts
+++ b/scripts/buildRadar.ts
@@ -42,12 +42,12 @@ const runCommand = (command: string) =>
   });
 
 const buildTemplate = () => {
-  const packageManager = fs.existsSync(paths.appYarnLock) ? "yarn" : "npx";
+  const packageManager = fs.existsSync(paths.appYarnLock) ? "yarn" : "npm";
 
   fs.emptyDirSync(paths.templateBuild);
   process.chdir(paths.template);
 
-  return runCommand(`${packageManager} build`);
+  return runCommand(`${packageManager} run build`);
 };
 
 buildTemplate().then(() => {


### PR DESCRIPTION
Running the build command currently does not work with `npm` (only with `yarn`). This fixes the `buildRadar` command so that both work.