### PR TITLE
Enable multiple radars

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,26 +156,26 @@ The content should look as follows:
 }
 ```
 
-### Create different Radars
-To create different radars with one set of blips put a `radars` entry in your frontmatter:
+### Filter with tags / create different Radars
+To create different radars with one set of blips put a `tags` entry in your frontmatter:
 ```yaml
 ---
 title: Item
 ring: adopt
 quadrant: tools
-radars: [radar-1, radar-2]
+tags: [radar-1, radar-2]
 ---
 ```
 
-Then, to select the blips put a `radar` entry in the `config.json` for generating the site:
+Then, to select the blips put a `tags` entry in the `config.json` for generating the site:
 ```json
 {
-  "radar": "radar-1",
+  "tags": ["radar-1"],
   "quadrants": {
     ...
 ```
 
-This will only add blips with the defined radar into the output.
+This will only add blips with the defined tags into the output.
 
 ### Change the index.html
 To change the index.html, create a public folder in your application and put your `index.html` in it.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,27 @@ The content should look as follows:
 }
 ```
 
+### Create different Radars
+To create different radars with one set of blips put a `radars` entry in your frontmatter:
+```yaml
+---
+title: Item
+ring: adopt
+quadrant: tools
+radars: [radar-1, radar-2]
+---
+```
+
+Then, to select the blips put a `radar` entry in the `config.json` for generating the site:
+```json
+{
+  "radar": "radar-1",
+  "quadrants": {
+    ...
+```
+
+This will only add blips with the defined radar into the output.
+
 ### Change the index.html
 To change the index.html, create a public folder in your application and put your `index.html` in it.
 

--- a/dist_scripts/scripts/generateJson/radar.js
+++ b/dist_scripts/scripts/generateJson/radar.js
@@ -120,7 +120,7 @@ var createRadar = function () { return __awaiter(void 0, void 0, void 0, functio
 }); };
 exports.createRadar = createRadar;
 var checkAttributes = function (fileName, attributes) {
-    var rawConf = fs_1.readFileSync(path.resolve(paths_1.appBuild, "config.json"), "utf-8");
+    var rawConf = (0, fs_1.readFileSync)(path.resolve(paths_1.appBuild, "config.json"), "utf-8");
     var config = JSON.parse(rawConf);
     if (!config.rings.includes(attributes.ring)) {
         throw new Error("Error: ".concat(fileName, " has an illegal value for 'ring' - must be one of ").concat(config.rings));
@@ -129,19 +129,25 @@ var checkAttributes = function (fileName, attributes) {
     if (!quadrants.includes(attributes.quadrant)) {
         throw new Error("Error: ".concat(fileName, " has an illegal value for 'quadrant' - must be one of ").concat(quadrants));
     }
-    if (config.radar && attributes.radars) {
-        if (!attributes.radars.includes(config.radar)) {
-            return undefined;
+    if (config.tags) {
+        for (var _i = 0, _a = config.tags; _i < _a.length; _i++) {
+            var tag = _a[_i];
+            if (attributes.tags && attributes.tags.includes(tag)) {
+                return attributes;
+            }
         }
+        return undefined;
     }
-    return attributes;
+    else {
+        return attributes;
+    }
 };
 var createRevisionsFromFiles = function (fileNames) {
     var publicUrl = process.env.PUBLIC_URL;
     return Promise.all(fileNames.map(function (fileName) {
-        return fs_extra_1.readFile(fileName, "utf8").then(function (data) {
-            var fm = front_matter_1.default(data);
-            var html = marked_1.marked(fm.body.replace(/\]\(\//g, "](" + publicUrl + "/"));
+        return (0, fs_extra_1.readFile)(fileName, "utf8").then(function (data) {
+            var fm = (0, front_matter_1.default)(data);
+            var html = (0, marked_1.marked)(fm.body.replace(/\]\(\//g, "](".concat(publicUrl, "/")));
             html = html.replace(/a href="http/g, 'a target="_blank" rel="noopener noreferrer" href="http');
             var attributes = checkAttributes(fileName, fm.attributes);
             if (attributes) {

--- a/dist_scripts/src/config.js
+++ b/dist_scripts/src/config.js
@@ -1,28 +1,12 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.assetUrl = exports.isMobileViewport = exports.translate = exports.showEmptyRings = exports.getItemPageNames = exports.rings = exports.quadrants = exports.radarNameShort = exports.radarName = void 0;
+exports.translate = exports.assetUrl = exports.isMobileViewport = exports.getItemPageNames = exports.radarNameShort = exports.radarName = void 0;
 exports.radarName = process.env.REACT_APP_RADAR_NAME || "AOE Technology Radar";
 exports.radarNameShort = exports.radarName;
-exports.quadrants = [
-    "languages-and-frameworks",
-    "methods-and-patterns",
-    "platforms-and-aoe-services",
-    "tools",
-];
-exports.rings = ["all", "adopt", "trial", "assess", "hold"];
 var getItemPageNames = function (items) {
-    return items.map(function (item) { return item.quadrant + "/" + item.name; });
+    return items.map(function (item) { return "".concat(item.quadrant, "/").concat(item.name); });
 };
 exports.getItemPageNames = getItemPageNames;
-exports.showEmptyRings = false;
-var messages = {
-    "languages-and-frameworks": "Languages & Frameworks",
-    "methods-and-patterns": "Methods & Patterns",
-    "platforms-and-aoe-services": "Platforms & Operations",
-    tools: "Tools",
-};
-var translate = function (key) { return messages[key] || "-"; };
-exports.translate = translate;
 function isMobileViewport() {
     // return false for server side rendering
     if (typeof window == "undefined")
@@ -37,3 +21,7 @@ function assetUrl(file) {
     return process.env.PUBLIC_URL + "/" + file;
 }
 exports.assetUrl = assetUrl;
+function translate(config, key) {
+    return config.quadrants[key] || "-";
+}
+exports.translate = translate;

--- a/scripts/generateJson/radar.ts
+++ b/scripts/generateJson/radar.ts
@@ -10,6 +10,8 @@ import { radarPath, getAllMarkdownFiles } from "./file";
 import { Item, Revision, ItemAttributes, Radar, FlagType } from "../../src/model";
 import { appBuild } from "../paths";
 
+import type { ConfigData } from "../../src/config";
+
 type FMAttributes = ItemAttributes;
 
 marked.setOptions({
@@ -34,7 +36,7 @@ export const createRadar = async (): Promise<Radar> => {
 
 const checkAttributes = (fileName: string, attributes: FMAttributes) => {
   const rawConf = readFileSync(path.resolve(appBuild, "config.json"), "utf-8");
-  const config = JSON.parse(rawConf);
+  const config = JSON.parse(rawConf) as ConfigData;
 
   if (!config.rings.includes(attributes.ring)) {
     throw new Error(
@@ -49,13 +51,17 @@ const checkAttributes = (fileName: string, attributes: FMAttributes) => {
     );
   }
 
-  if (config.radar && attributes.radars) {
-    if (!attributes.radars.includes(config.radar)) {
-      return undefined;
+  if (config.tags) {
+    for (let tag of config.tags) {
+      if (attributes.tags && attributes.tags.includes(tag)) {
+        return attributes;
+      }
     }
+    return undefined;
+  } else {
+    return attributes;
   }
 
-  return attributes;
 };
 
 const createRevisionsFromFiles = (fileNames: string[]) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import {Item, HomepageOption, QuadrantConfig} from './model';
 
 export interface ConfigData {
+  tags?: string[];
   quadrants: { [key: string]: string };
   rings: string[];
   showEmptyRings: boolean;

--- a/src/model.ts
+++ b/src/model.ts
@@ -10,6 +10,7 @@ export type ItemAttributes = {
   quadrant: string;
   title: string;
   featured?: boolean;
+  radars?: string[];
 };
 
 export enum FlagType {

--- a/src/model.ts
+++ b/src/model.ts
@@ -10,7 +10,7 @@ export type ItemAttributes = {
   quadrant: string;
   title: string;
   featured?: boolean;
-  radars?: string[];
+  tags?: string[];
 };
 
 export enum FlagType {


### PR DESCRIPTION
This enables users to create different radars with the same set of Markdown files.

To create different radars with one set of blips put a `radars` entry in your frontmatter:
```yaml
---
title: Item
ring: adopt
quadrant: tools
radars: [radar-1, radar-2]
---
```

Then, to select the blips put a `radar` entry in the `config.json` for generating the site:
```json
{
  "radar": "radar-1",
  "quadrants": {
    ...
```
This will only add blips with the defined radar into the output.

This enables to separate radars similar to this feature request: #6