### PR TITLE
Update Readme to fix initial setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ npx aoe_technology_radar-createStaticFiles
 ## Authoring Techradar contents
 For a new Technology Radar release, create a folder of the release date (YYYY-MM-DD) under `./radar`.
 
-In each release folder create a folder for every quadrant and place the items there.
-
 ### Maintaining items
 The items are written in Markdown format (.md)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Generate the `rd.json` file containing the radar data
 npx aoe_technology_radar-generateJson
 ```
 
+Run the Prepare script 
+```
+npm run prepare
+```
+
 Serve
 ```
 cd build


### PR DESCRIPTION
The examples don't have quadrant subfolders any more. Is that correct?