### PR TITLE
fix: deterministic behaviour for radar by storing the random fractions when generating rd.json

### DIFF
--- a/dist_scripts/scripts/generateJson/radar.js
+++ b/dist_scripts/scripts/generateJson/radar.js
@@ -199,6 +199,8 @@ var addRevisionToItem = function (item, revision) {
         quadrant: "",
         body: "",
         info: "",
+        angleFraction: Math.random(),
+        radiusFraction: Math.random()
     }; }
     var newItem = __assign(__assign(__assign({}, item), revision), { body: ignoreEmptyRevisionBody(revision, item) });
     if (revisionCreatesNewHistoryEntry(revision, item)) {

--- a/scripts/generateJson/radar.ts
+++ b/scripts/generateJson/radar.ts
@@ -146,6 +146,8 @@ const addRevisionToItem = (
     quadrant: "",
     body: "",
     info: "",
+    angleFraction: Math.random(),
+    radiusFraction: Math.random()
   },
   revision: Revision
 ): Item => {

--- a/src/components/Chart/BlipPoints.tsx
+++ b/src/components/Chart/BlipPoints.tsx
@@ -26,12 +26,14 @@ function generateCoordinates(
     ringPadding = 0.7;
 
   // radian between 0 and 90 degrees
-  const randomDegree = (Math.random() * 90 * pi) / 180;
+  const randomDegree = ((blip.angleFraction || Math.random()) * 90 * pi) / 180;
   // random distance from the centre of the radar, but within given ring. Also, with some "padding" so the points don't touch ring borders.
-  const radius = randomBetween(
+  const radius = pointBetween(
     previousRingRadius + ringPadding,
-    ringRadius - ringPadding
+    ringRadius - ringPadding,
+    blip.radiusFraction || Math.random()
   );
+
   /* 
     Multiples of PI/2. To apply the calculated position to the specific quadrant.
     Order here is counter-clockwise, so we need to "invert" quadrant positions (i.e. swap 2 with 4)
@@ -44,8 +46,8 @@ function generateCoordinates(
   };
 }
 
-function randomBetween(min: number, max: number): number {
-  return Math.random() * (max - min) + min;
+function pointBetween(min: number, max: number, amount: number): number {
+  return amount * (max - min) + min;
 }
 
 function distanceBetween(point1: Point, point2: Point): number {

--- a/src/components/Chart/BlipPoints.tsx
+++ b/src/components/Chart/BlipPoints.tsx
@@ -26,7 +26,7 @@ function generateCoordinates(
     ringPadding = 0.7;
 
   // radian between 0 and 90 degrees
-  const randomDegree = ((blip.angleFraction || Math.random()) * 90 * pi) / 180;
+  const randomDegree = ((0.1 + (blip.angleFraction || Math.random()) * .8) * 90 * pi) / 180;
   // random distance from the centre of the radar, but within given ring. Also, with some "padding" so the points don't touch ring borders.
   const radius = pointBetween(
     previousRingRadius + ringPadding,
@@ -34,7 +34,7 @@ function generateCoordinates(
     blip.radiusFraction || Math.random()
   );
 
-  /* 
+  /*
     Multiples of PI/2. To apply the calculated position to the specific quadrant.
     Order here is counter-clockwise, so we need to "invert" quadrant positions (i.e. swap 2 with 4)
     */

--- a/src/model.ts
+++ b/src/model.ts
@@ -25,6 +25,8 @@ export type Item = ItemAttributes & {
   info: string;
   flag: FlagType;
   revisions: Revision[];
+  angleFraction?: number;
+  radiusFraction?: number;
 };
 
 export type Blip = Item & {


### PR DESCRIPTION
closes #148

Potentially simple solution to creating stable blips is to store the randomly generated angle and radius in `rg.json`.

Attempted a few hash functions but found it hard to spread blips 'nicely'... they tended to clump into groups or sections of the radar. Tempted to investigate why further but found this solution works OK for us.