### PR TITLE
feat: show date of latest revision on item page

### DIFF
--- a/src/components/PageItem/PageItem.tsx
+++ b/src/components/PageItem/PageItem.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { ConfigData, translate } from "../../config";
+import { formatRelease } from "../../date";
 import { useMessages } from "../../context/MessagesContext";
 import { Item, groupByQuadrants } from "../../model";
 import Badge from "../Badge/Badge";
@@ -120,7 +121,7 @@ const PageItem: React.FC<Props> = ({
                 </div>
                 <div className="split__right">
                   <Badge big type={item.ring} config={config}>
-                    {item.ring}
+                    {item.ring} | {formatRelease(item.revisions[0].release, config.dateFormat)}
                   </Badge>
                 </div>
               </div>

--- a/src/components/PageItemMobile/PageItemMobile.tsx
+++ b/src/components/PageItemMobile/PageItemMobile.tsx
@@ -1,4 +1,5 @@
 import { ConfigData, translate } from "../../config";
+import { formatRelease } from "../../date";
 import { Item, groupByQuadrants } from "../../model";
 import Badge from "../Badge/Badge";
 import EditButton from "../EditButton/EditButton";
@@ -66,7 +67,7 @@ export default function PageItemMobile({
                 </div>
                 <div className="split__right">
                   <Badge big type={item.ring} config={config}>
-                    {item.ring}
+                    {item.ring} | {formatRelease(item.revisions[0].release, config.dateFormat)}
                   </Badge>
                 </div>
               </div>


### PR DESCRIPTION
This will show the date of the latest revision on the items page. At the moment this is missing, so you don't know how long ago a specific technology was adopted/hold/etc.

Before:
![image](https://github.com/AOEpeople/aoe_technology_radar/assets/1814883/e52247d5-4950-40fe-96ec-3f125daa19c1)
![image](https://github.com/AOEpeople/aoe_technology_radar/assets/1814883/353cb101-3e70-4de2-8e12-3cf001a16b5e)

After:
![image](https://github.com/AOEpeople/aoe_technology_radar/assets/1814883/4640ef74-a04f-4ade-8f68-468f4dab6a7d)
![image](https://github.com/AOEpeople/aoe_technology_radar/assets/1814883/717f8d27-cd8f-4dad-87e3-d4937106ce23)
