### PR TITLE
Fix tooltips disappearing

### DIFF
--- a/src/components/Chart/RadarChart.tsx
+++ b/src/components/Chart/RadarChart.tsx
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import React from "react";
+import React, { useEffect } from "react";
 import ReactTooltip from "react-tooltip";
 
 import { ConfigData } from "../../config";
@@ -62,6 +62,10 @@ const RadarChart: React.FC<{
     .scaleLinear()
     .domain(config.chartConfig.scale)
     .range([config.chartConfig.size, 0]);
+
+  useEffect(() => {
+    ReactTooltip.rebuild();
+  }, [items]);
 
   return (
     <div className="chart" style={{ maxWidth: `${config.chartConfig.size}px` }}>


### PR DESCRIPTION
Currently, when you look at the [radar](https://www.aoe.com/techradar/index.html) with no filtering, the tooltips work.

When you apply a filter so blips disappear, then remove the filter so they reappear, the tooltips are missing.

This rebuilds the tooltips when the items change, so the tooltips stay.