### PR TITLE
fix: uri-encode tag when used as query parameter

### DIFF
--- a/src/components/Tags/Tags.tsx
+++ b/src/components/Tags/Tags.tsx
@@ -20,7 +20,7 @@ export function Tag({ tag, isActive, className, ...props }: TagProps) {
     <Link
       {...props}
       className={cn(styles.tag, className, isActive && styles.active)}
-      href={isActive ? "/" : `/?tag=${tag}`}
+      href={isActive ? "/" : `/?tag=${encodeURIComponent(tag)}`}
     >
       <Icon className={cn(styles.icon)} />
       <span className={styles.label}>{tag}</span>


### PR DESCRIPTION
Fixes #470

Uses `encodeURIComponent` when creating the tag link, so that ampersands in tags can work as expected.

Tested locally by adding tag 'x&y' to one of the demo radar items.