### PR TITLE
feat: restore scroll position when navigating back

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,9 @@ const nextConfig = {
   output: "export",
   trailingSlash: true,
   reactStrictMode: true,
+  experimental: {
+    scrollRestoration: true,
+  },
 };
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aoe_technology_radar",
-  "version": "4.4.0-rc.1",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aoe_technology_radar",
-      "version": "4.4.0-rc.1",
+      "version": "4.4.0",
       "hasInstallScript": true,
       "bin": {
         "techradar": "bin/techradar.js"


### PR DESCRIPTION
Before:
Navigating to technology, and clicking browser's back button always scrolls to top of the page.

After:
Navigating to technology, and clicking browser's back button restores previous scroll position.