### PR TITLE
Add radar SVG as static file

### DIFF
--- a/src/components/Radar/Chart.tsx
+++ b/src/components/Radar/Chart.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import React, { FC, Fragment, memo } from "react";
+import fs from "fs";
+import path from "path";
 
 import styles from "./Chart.module.css";
 
@@ -132,7 +134,12 @@ const _Chart: FC<ChartProps> = ({
     });
   };
 
-  return (
+  const exportRadarSVG = (svgContent: string) => {
+    const filePath = path.join(process.cwd(), "public", "radar.svg");
+    fs.writeFileSync(filePath, svgContent);
+  };
+
+  const svgContent = (
     <svg
       className={className}
       width={viewBoxSize}
@@ -158,6 +165,10 @@ const _Chart: FC<ChartProps> = ({
       <g className={styles.ringLabels}>{renderRingLabels()}</g>
     </svg>
   );
+
+  exportRadarSVG(svgContent);
+
+  return svgContent;
 };
 
 export const Chart = memo(_Chart);


### PR DESCRIPTION
Fixes #516

Add a static radar SVG file for inclusion on other sites.

* Import `fs` and `path` modules in `src/components/Radar/Chart.tsx`.
* Add a function to export the radar SVG to `public/radar.svg`.
* Call the export function after rendering the radar SVG.
* Update the return statement to return the SVG content.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AOEpeople/aoe_technology_radar/pull/517?shareId=2e16a830-bc39-4552-8596-7b7d04c56695).