### PR TITLE
feat: render ring description on hover

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -70,7 +70,7 @@ export function RingBadge({
   const label = release
     ? `${ring.title} | ${formatRelease(release)}`
     : ring.title;
-  const description = title ?? ring.description ?? undefined;
+  const description = title || ring.description || undefined;
 
   return (
     <Badge color={ring.color} title={description} {...props}>

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -61,6 +61,7 @@ interface RingBadgeProps extends Omit<BadgeProps, "color" | "children"> {
 export function RingBadge({
   ring: ringName,
   release,
+  title,
   ...props
 }: RingBadgeProps) {
   const ring = getRing(ringName);
@@ -69,9 +70,10 @@ export function RingBadge({
   const label = release
     ? `${ring.title} | ${formatRelease(release)}`
     : ring.title;
+  const description = title ?? ring.description ?? undefined;
 
   return (
-    <Badge color={ring.color} {...props}>
+    <Badge color={ring.color} title={description} {...props}>
       {label}
     </Badge>
   );

--- a/src/components/Radar/Chart.tsx
+++ b/src/components/Radar/Chart.tsx
@@ -116,7 +116,6 @@ const _Chart: FC<ChartProps> = ({
             textAnchor="middle"
             dominantBaseline="middle"
             fontSize="12"
-            title={description}
           >
             {description && <title>{description}</title>}
             {ring.title}
@@ -127,7 +126,6 @@ const _Chart: FC<ChartProps> = ({
             textAnchor="middle"
             dominantBaseline="middle"
             fontSize="12"
-            title={description}
           >
             {description && <title>{description}</title>}
             {ring.title}

--- a/src/components/Radar/Chart.tsx
+++ b/src/components/Radar/Chart.tsx
@@ -106,6 +106,7 @@ const _Chart: FC<ChartProps> = ({
       const outerRadius = ring.radius || 1;
       const innerRadius = rings[index - 1]?.radius || 0;
       const position = ((outerRadius + innerRadius) / 2) * center;
+      const description = ring.description || undefined;
 
       return (
         <Fragment key={ring.id}>
@@ -115,7 +116,9 @@ const _Chart: FC<ChartProps> = ({
             textAnchor="middle"
             dominantBaseline="middle"
             fontSize="12"
+            title={description}
           >
+            {description && <title>{description}</title>}
             {ring.title}
           </text>
           <text
@@ -124,7 +127,9 @@ const _Chart: FC<ChartProps> = ({
             textAnchor="middle"
             dominantBaseline="middle"
             fontSize="12"
+            title={description}
           >
+            {description && <title>{description}</title>}
             {ring.title}
           </text>
         </Fragment>


### PR DESCRIPTION
feat: renders ring descriptions on hover

* on hover in chart, render ring description
* on hover in badge, render ring description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds native hover tooltips; main risk is minor UX/accessibility differences or missing descriptions yielding no tooltip.
> 
> **Overview**
> Adds hover tooltips for ring descriptions in two places.
> 
> `RingBadge` now passes a `title` attribute to the underlying `Badge`, using an explicit `title` prop when provided or falling back to the ring’s `description`. The radar `Chart` ring label `<text>` nodes now include an SVG `<title>` so hovering ring labels shows the ring description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4009cca11b745bbc53513bb332609096bdfff2b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->