### PR TITLE
feat: simplify internal cross links (#549)

### DIFF
--- a/data/radar/2024-03-01/demo-5.md
+++ b/data/radar/2024-03-01/demo-5.md
@@ -1,0 +1,26 @@
+---
+title: "Demo 5"
+ring: trial
+quadrant: tools
+tags: [new]
+---
+
+This is a demo item illustrating the optimized internal linking convention.
+
+### Internal Linking
+
+The build process now automatically resolves internal IDs to their full quadrant paths.
+
+**Example:**
+This item references another entry: [Demo 4](demo-4).
+
+During the build, the link above is automatically transformed:
+
+- **Input:** `<a href="demo-4">`
+- **Output:** `<a href="/techradar/tools/demo-4/">` (The quadrant is resolved automatically)
+
+### Rules for Link Resolution:
+
+- **Simplified ID:** Use only the item ID (e.g., `demo-4`). Do not include `.html` or leading slashes.
+- **Allowed Characters:** Only alphanumeric characters, underscores (`_`), and hyphens (`-`) are processed.
+- **Automatic Filtering:** Links containing dots (e.g., `file.html`), slashes (e.g., `/manual/`), or protocols (e.g., `https://`) are ignored by the mapper and kept as-is.

--- a/scripts/buildData.ts
+++ b/scripts/buildData.ts
@@ -239,6 +239,32 @@ function postProcessItems(items: Item[]): {
     return processedItem;
   });
 
+  const base = nextConfig.basePath || "";
+
+  // Pre-calculate all valid item paths
+  const idToPath: Record<string, string> = {};
+  for (const it of processedItems) {
+    if (it.id && it.quadrant) {
+      idToPath[it.id] = `${base}/${it.quadrant}/${it.id}/`;
+    }
+  }
+
+  // Matches internal IDs only (alphanumeric, underscores, hyphens)
+  // This skips links containing dots (files), slashes (paths), or protocols (http)
+  const internalHrefRegex = /href=(["'])([A-Za-z0-9_-]+)\1/g;
+
+  for (const it of processedItems) {
+    if (!it.body) continue;
+
+    it.body = it.body.replace(
+      internalHrefRegex,
+      (match, quote, candidateId) => {
+        const targetPath = idToPath[candidateId];
+        return targetPath ? `href=${quote}${targetPath}${quote}` : match;
+      },
+    );
+  }
+
   return { releases, tags: uniqueTags, items: processedItems };
 }
 

--- a/scripts/buildData.ts
+++ b/scripts/buildData.ts
@@ -254,15 +254,33 @@ function postProcessItems(items: Item[]): {
   const internalHrefRegex = /href=(["'])([A-Za-z0-9_-]+)\1/g;
 
   for (const it of processedItems) {
-    if (!it.body) continue;
+    // map simple internal hrefs in the main item body
+    if (it.body) {
+      it.body = it.body.replace(
+        internalHrefRegex,
+        (match, quote, candidateId) => {
+          const targetPath = idToPath[candidateId];
+          return targetPath ? `href=${quote}${targetPath}${quote}` : match;
+        },
+      );
+    }
 
-    it.body = it.body.replace(
-      internalHrefRegex,
-      (match, quote, candidateId) => {
-        const targetPath = idToPath[candidateId];
-        return targetPath ? `href=${quote}${targetPath}${quote}` : match;
-      },
-    );
+    // map links inside revision bodies
+    if (it.revisions && it.revisions.length) {
+      it.revisions = it.revisions.map((rev) => {
+        if (!rev.body) return rev;
+        return {
+          ...rev,
+          body: rev.body.replace(
+            internalHrefRegex,
+            (match, quote, candidateId) => {
+              const targetPath = idToPath[candidateId];
+              return targetPath ? `href=${quote}${targetPath}${quote}` : match;
+            },
+          ),
+        };
+      });
+    }
   }
 
   return { releases, tags: uniqueTags, items: processedItems };


### PR DESCRIPTION
This PR introduces a new automated link resolution mechanism to simplify cross-linking between Radar items. Previously, contributors had to manually provide full paths. Now, the builder handles quadrant-specific routing automatically based on item IDs.

**Features Added:**
- Regex-based Link Transformer: Integrated a new processing step that identifies internal href targets using a specific character set (alphanumeric, underscores, hyphens).
- New Documentation & Test Case: Added Demo 5 as a reference item to demonstrate and verify the transformation logic during the build process.

Closes: #549

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the build pipeline to rewrite `href` values across all radar item HTML bodies, which could break or mis-route links if the mapping/regex misses edge cases or duplicate IDs.
> 
> **Overview**
> **Simplifies cross-linking between Radar items** by teaching `scripts/buildData.ts` to rewrite HTML `href` values that look like internal item IDs (alphanumeric/`_`/`-`) into full `basePath` + `quadrant` + `id` URLs, applied to both item bodies and revision bodies.
> 
> Adds a new `data/radar/2024-03-01/demo-5.md` entry documenting and demonstrating the expected link transformation and the cases that should be ignored (dots, slashes, protocols).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a542790bc95d20fcc39af88c9ddfe23d73cf9fe1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->